### PR TITLE
Deprecate statusText

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,10 @@
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
-    "extends": "react-app"
+    "extends": "react-app",
+    "rules": {
+      "@typescript-eslint/no-unused-vars": "off"
+    }
   },
   "browserslist": {
     "production": [

--- a/src/exercises/components.tsx
+++ b/src/exercises/components.tsx
@@ -395,7 +395,7 @@ export const ConvertSuccessIntoErrorWithThrow: React.FC = () => {
             directions={directions.convertSuccessfulFetchIntoError}
             headers={[['Error Message']]}
             data={[[errorMessage]]}
-            expectedResult={'Not Found'}
+            expectedResult={404}
             result={errorMessage} />
     )
 }
@@ -471,7 +471,7 @@ export const CreateYourOwnFetch: React.FC = () => {
             directions={directions.createYourOwnFetch}
             headers={[['Results']]}
             data={arrayToRows(messages)}
-            expectedResult={['jojade74', 'Not Found']}
+            expectedResult={['jojade74', 404]}
             result={messages}
         />
     )

--- a/src/exercises/components.tsx
+++ b/src/exercises/components.tsx
@@ -296,7 +296,7 @@ export const FindUsersNamed: React.FC = () => {
         "nusi",
         "nuzesy"
     ];
-    const userNamesAsRows: number[][] = _.toArray(_.chunk(userNames, 1))
+    const userNamesAsRows: string[][] = _.toArray(_.chunk(userNames, 1))
 
     return (
         <ExerciseComponent
@@ -328,7 +328,7 @@ export const FindUniqueUsersByName: React.FC = () => {
         "nusi",
         "nuzesy"
     ]
-    const userNamesAsRows: number[][] = _.toArray(_.chunk(userNames, 1))
+    const userNamesAsRows: string[][] = _.toArray(_.chunk(userNames, 1))
 
     return (
         <ExerciseComponent

--- a/src/exercises/directions.ts
+++ b/src/exercises/directions.ts
@@ -208,7 +208,7 @@ export const convertSuccessfulFetchIntoError = `
 
 ### Goal
 
-By default \`fromFetch\` will emit a successful response in the event of 404 or other HTTP failures. Many other libraries will emit an error in that case, completing the subscription. In this puzzle use \`fromFetch\` to make the web request, but map the responses statusText to an error.
+By default \`fromFetch\` will emit a successful response in the event of 404 or other HTTP failures. Many other libraries will emit an error in that case, completing the subscription. In this puzzle use \`fromFetch\` to make the web request, but map the responses status to an error.
 
 ### New Operators
 * \`response\` - use the response object's other methods to determine the error message.
@@ -258,7 +258,7 @@ export const createYourOwnFetch = `
 
 ### Goal
 
-Don't use the \`fromFetch\` or \`fromPromise\` but instead create and return an Observable using that wraps the built in fetch function \`Observalbe.create\`. Your observable should always emit the json blob instead of the response object, and should emit an error with the status text when the response is not 'ok'. If you do this right you'll get two results on the page.
+Don't use the \`fromFetch\` or \`fromPromise\` but instead create and return an Observable using that wraps the built in fetch function \`Observalbe.create\`. Your observable should always emit the json blob instead of the response object, and should emit an error with the status code when the response is not 'ok'. If you do this right you'll get two results on the page.
 
 ### New Operators
 


### PR DESCRIPTION
HTTP/2 does not have the concept of reason phrase, and statusText for HTTP/2 is not implemented consistently across browsers. See: whatwg/fetch#599 for more details.